### PR TITLE
[Feature] 오늘의 포켓몬 정보 API 요청

### DIFF
--- a/PokemonDex/TodaysPokemonViewController.swift
+++ b/PokemonDex/TodaysPokemonViewController.swift
@@ -7,6 +7,428 @@
 
 import UIKit
 
+struct PokemonInfo: Codable {
+    var abilities: [PokemonAbility]
+    var baseExperience: Int
+    var cries: PokemonCries
+    var forms: [PokemonForm]
+    var gameIndices: [PokemonGameIndex]
+    var height: Int
+    var id: Int
+    var isDefault: Bool
+    var locationAreaEncounters: String
+    var moves: [PokemonMove]
+    var name: String
+    var order: Int
+    var species: PokemonSpecies
+    var sprites: PokemonSprites
+    var stats: [PokemonStat]
+    var types: [PokemonType]
+    var weight: Int
+
+    enum CodingKeys: String, CodingKey {
+        case abilities
+        case baseExperience = "base_experience"
+        case cries
+        case forms
+        case gameIndices = "game_indices"
+        case height
+        case id
+        case isDefault = "is_default"
+        case locationAreaEncounters = "location_area_encounters"
+        case moves
+        case name
+        case order
+        case species
+        case sprites
+        case stats
+        case types
+        case weight
+    }
+}
+
+struct PokemonAbility: Codable {
+    var ability: PokemonAbilityComponent
+    var isHidden: Bool
+    var slot: Int
+
+    enum CodingKeys: String, CodingKey {
+        case ability
+        case isHidden = "is_hidden"
+        case slot
+    }
+}
+
+struct PokemonAbilityComponent: Codable {
+    var name: String
+    var url: String
+}
+
+struct PokemonCries: Codable {
+    var latest: String
+    var legacy: String?
+}
+
+struct PokemonForm: Codable {
+    var name: String
+    var url: String
+}
+
+struct PokemonGameIndex: Codable {
+    var gameIndex: Int
+    var version: PokemonGameIndexVersion
+
+    enum CodingKeys: String, CodingKey {
+        case gameIndex = "game_index"
+        case version
+    }
+}
+
+struct PokemonGameIndexVersion: Codable {
+    var name: String
+    var url: String
+}
+
+struct PokemonMove: Codable {
+    var move: PokemonMoveComponent
+    var versionGroupDetails: [PokemonMoveVersionGroupDetail]
+
+    enum CodingKeys: String, CodingKey {
+        case move
+        case versionGroupDetails = "version_group_details"
+    }
+}
+
+struct PokemonMoveComponent: Codable {
+    var name: String
+    var url: String
+}
+
+struct PokemonMoveVersionGroupDetail: Codable {
+    var levelLearnedAt: Int
+    var moveLearnMethod: PokemonMoveLearnMethod
+    var versionGroup: PokemonMoveVersionGroup
+
+    enum CodingKeys: String, CodingKey {
+        case levelLearnedAt = "level_learned_at"
+        case moveLearnMethod = "move_learn_method"
+        case versionGroup = "version_group"
+    }
+}
+
+struct PokemonMoveLearnMethod: Codable {
+    var name: String
+    var url: String
+}
+
+struct PokemonMoveVersionGroup: Codable {
+    var name: String
+    var url: String
+}
+
+struct PokemonSpecies: Codable {
+    var name: String
+    var url: String
+}
+
+struct PokemonSprites: Codable {
+    var backDefault: String?
+    var backFemale: String?
+    var backShiny: String?
+    var backShinyFemale: String?
+    var frontDefault: String?
+    var frontFemale: String?
+    var frontShiny: String?
+    var frontShinyFemale: String?
+    var other: PokemonSpritesOther
+    var versions: PokemonSpritesVersions
+
+    enum CodingKeys: String, CodingKey {
+        case backDefault = "back_default"
+        case backFemale = "back_female"
+        case backShiny = "back_shiny"
+        case backShinyFemale = "back_shiny_female"
+        case frontDefault = "front_default"
+        case frontFemale = "front_female"
+        case frontShiny = "front_shiny"
+        case frontShinyFemale = "front_shiny_female"
+        case other
+        case versions
+    }
+}
+
+struct PokemonSpritesComponent: Codable {
+    var backDefault: String?
+    var backGray: String?
+    var backTransparent: String?
+    var backFemale: String?
+    var backShiny: String?
+    var backShinyTransparent: String?
+    var backShinyFemale: String?
+    var frontDefault: String?
+    var frontGray: String?
+    var frontTransparent: String?
+    var frontFemale: String?
+    var frontShiny: String?
+    var frontShinyTransparent: String?
+    var frontShinyFemale: String?
+    var animated: PokemonAnimatedSpritesComponent?
+
+    enum CodingKeys: String, CodingKey {
+        case backDefault = "back_default"
+        case backGray = "back_gray"
+        case backTransparent = "back_transparent"
+        case backFemale = "back_female"
+        case backShiny = "back_shiny"
+        case backShinyTransparent = "back_shiny_transparent"
+        case backShinyFemale = "back_shiny_female"
+        case frontDefault = "front_default"
+        case frontGray = "front_gray"
+        case frontTransparent = "front_transparent"
+        case frontFemale = "front_female"
+        case frontShiny = "front_shiny"
+        case frontShinyTransparent = "front_shiny_transparent"
+        case frontShinyFemale = "front_shiny_female"
+        case animated
+    }
+}
+
+struct PokemonAnimatedSpritesComponent: Codable {
+    var backDefault: String?
+    var backGray: String?
+    var backTransparent: String?
+    var backFemale: String?
+    var backShiny: String?
+    var backShinyTransparent: String?
+    var backShinyFemale: String?
+    var frontDefault: String?
+    var frontGray: String?
+    var frontTransparent: String?
+    var frontFemale: String?
+    var frontShiny: String?
+    var frontShinyTransparent: String?
+    var frontShinyFemale: String?
+
+    enum CodingKeys: String, CodingKey {
+        case backDefault = "back_default"
+        case backGray = "back_gray"
+        case backTransparent = "back_transparent"
+        case backFemale = "back_female"
+        case backShiny = "back_shiny"
+        case backShinyTransparent = "back_shiny_transparent"
+        case backShinyFemale = "back_shiny_female"
+        case frontDefault = "front_default"
+        case frontGray = "front_gray"
+        case frontTransparent = "front_transparent"
+        case frontFemale = "front_female"
+        case frontShiny = "front_shiny"
+        case frontShinyTransparent = "front_shiny_transparent"
+        case frontShinyFemale = "front_shiny_female"
+    }
+}
+
+struct PokemonSpritesOther: Codable {
+    var dreamWorld: PokemonSpritesComponent
+    var home: PokemonSpritesComponent
+    var officialArtwork: PokemonSpritesComponent
+    var showdown: PokemonSpritesComponent
+
+    enum CodingKeys: String, CodingKey {
+        case dreamWorld = "dream_world"
+        case home
+        case officialArtwork = "official-artwork"
+        case showdown
+    }
+}
+
+struct PokemonSpritesVersions: Codable {
+    var generationI: PokemonSpritesGenerationI
+    var generationII: PokemonSpritesGenerationII
+    var generationIII: PokemonSpritesGenerationIII
+    var generationIV: PokemonSpritesGenerationIV
+    var generationV: PokemonSpritesGenerationV
+    var generationVI: PokemonSpritesGenerationVI
+    var generationVII: PokemonSpritesGenerationVII
+    var generationVIII: PokemonSpritesGenerationVIII
+
+    enum CodingKeys: String, CodingKey {
+        case generationI = "generation-i"
+        case generationII = "generation-ii"
+        case generationIII = "generation-iii"
+        case generationIV = "generation-iv"
+        case generationV = "generation-v"
+        case generationVI = "generation-vi"
+        case generationVII = "generation-vii"
+        case generationVIII = "generation-viii"
+    }
+}
+
+struct PokemonSpritesGenerationI: Codable {
+    var redBlue: PokemonSpritesComponent
+    var yellow: PokemonSpritesComponent
+
+    enum CodingKeys: String, CodingKey {
+        case redBlue = "red-blue"
+        case yellow
+    }
+}
+
+struct PokemonSpritesGenerationII: Codable {
+    var crystal: PokemonSpritesComponent
+    var gold: PokemonSpritesComponent
+    var silver: PokemonSpritesComponent
+}
+
+struct PokemonSpritesGenerationIII: Codable {
+    var emerald: PokemonSpritesComponent
+    var fireredLeafgreen: PokemonSpritesComponent
+    var rubySapphire: PokemonSpritesComponent
+
+    enum CodingKeys: String, CodingKey {
+        case emerald
+        case fireredLeafgreen = "firered-leafgreen"
+        case rubySapphire = "ruby-sapphire"
+    }
+}
+
+struct PokemonSpritesGenerationIV: Codable {
+    var diamondPearl: PokemonSpritesComponent
+    var heartgoldSoulsilver: PokemonSpritesComponent
+    var platinum: PokemonSpritesComponent
+
+    enum CodingKeys: String, CodingKey {
+        case diamondPearl = "diamond-pearl"
+        case heartgoldSoulsilver = "heartgold-soulsilver"
+        case platinum
+    }
+}
+
+struct PokemonSpritesGenerationV: Codable {
+    var blackWhite: PokemonSpritesComponent
+
+    enum CodingKeys: String, CodingKey {
+        case blackWhite = "black-white"
+    }
+}
+
+struct PokemonSpritesGenerationVI: Codable {
+    var omegarubyAlphasapphire: PokemonSpritesComponent
+    var xy: PokemonSpritesComponent
+
+    enum CodingKeys: String, CodingKey {
+        case omegarubyAlphasapphire = "omegaruby-alphasapphire"
+        case xy = "x-y"
+    }
+}
+
+struct PokemonSpritesGenerationVII: Codable {
+    var icons: PokemonSpritesComponent
+    var ultraSunUltraMoon: PokemonSpritesComponent
+
+    enum CodingKeys: String, CodingKey {
+        case icons
+        case ultraSunUltraMoon = "ultra-sun-ultra-moon"
+    }
+}
+
+struct PokemonSpritesGenerationVIII: Codable {
+    var icons: PokemonSpritesComponent
+}
+
+struct PokemonStat: Codable {
+    var baseStat: Int
+    var effort: Int
+    var stat: PokemonStatComponent
+
+    enum CodingKeys: String, CodingKey {
+        case baseStat = "base_stat"
+        case effort
+        case stat
+    }
+}
+
+struct PokemonStatComponent: Codable {
+    var name: String
+    var url: String
+}
+
+struct PokemonType: Codable {
+    var slot: Int
+    var type: PokemonTypeComponent
+}
+
+struct PokemonTypeComponent: Codable {
+    var name: String
+    var url: String
+}
+
+struct PokemonSpeciesInfo: Codable {
+    var flavorTextEntries: [PokedexFlavorText]
+    var genera: [PokedexGenus]
+    var id: Int
+    var name: String
+    var names: [PokedexName]
+    var order: Int
+    var pokedexNumbers: [PokedexNumber]
+
+    enum CodingKeys: String, CodingKey {
+        case flavorTextEntries = "flavor_text_entries"
+        case genera
+        case id
+        case name
+        case names
+        case order
+        case pokedexNumbers = "pokedex_numbers"
+    }
+}
+
+struct PokedexFlavorText: Codable {
+    var flavorText: String
+    var language: PokedexLanguage
+    var version: PokedexVersion
+
+    enum CodingKeys: String, CodingKey {
+        case flavorText = "flavor_text"
+        case language
+        case version
+    }
+}
+
+struct PokedexLanguage: Codable {
+    var name: String
+    var url: String
+}
+
+struct PokedexVersion: Codable {
+    var name: String
+    var url: String
+}
+
+struct PokedexGenus: Codable {
+    var genus: String
+    var language: PokedexLanguage
+}
+
+struct PokedexName: Codable {
+    var language: PokedexLanguage
+    var name: String
+}
+
+struct PokedexNumber: Codable {
+    var entryNumber: Int
+    var pokedex: PokedexNumberInfo
+
+    enum CodingKeys: String, CodingKey {
+        case entryNumber = "entry_number"
+        case pokedex
+    }
+}
+
+struct PokedexNumberInfo: Codable {
+    var name: String
+    var url: String
+}
+
 class TodaysPokemonViewController: UIViewController {
 
     private let todaysPokemonBackground: UIView = {

--- a/PokemonDex/TodaysPokemonViewController.swift
+++ b/PokemonDex/TodaysPokemonViewController.swift
@@ -679,6 +679,238 @@ class TodaysPokemonViewController: UIViewController {
             pokemonSprite.heightAnchor.constraint(equalTo: pokemonSprite.widthAnchor),
             todaysPokemonFooter.heightAnchor.constraint(equalTo: titleStack.heightAnchor)
         ])
+
+        let number = Int.random(in: 1...1025)
+        pokemonNumber.text = "No.\(number)"
+
+        guard let pokemonUrl = URL(string: "https://pokeapi.co/api/v2/pokemon/\(number)") else { return }
+        let pokemonRequest = URLRequest(url: pokemonUrl)
+
+        URLSession(configuration: .default).dataTask(with: pokemonRequest) { data, response, error in
+            if let error {
+                print("Error: \(error.localizedDescription)")
+                return
+            }
+
+            guard let data else {
+                print("Error: Request fail")
+                return
+            }
+
+            guard let json = try? JSONDecoder().decode(PokemonInfo.self, from: data) else {
+                print("Error: Data Decoding error")
+                return
+            }
+
+            DispatchQueue.main.async {
+                switch json.types.filter { $0.slot == 1 }[0].type.name {
+                case "normal":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Normal")
+                    self.pokemonType1Text.text = "노말"
+                    self.pokemonType1Background.backgroundColor = TypeColor.normal
+                case "fire":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Fire")
+                    self.pokemonType1Text.text = "불꽃"
+                    self.pokemonType1Background.backgroundColor = TypeColor.fire
+                case "water":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Water")
+                    self.pokemonType1Text.text = "물"
+                    self.pokemonType1Background.backgroundColor = TypeColor.water
+                case "grass":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Grass")
+                    self.pokemonType1Text.text = "풀"
+                    self.pokemonType1Background.backgroundColor = TypeColor.grass
+                case "electric":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Electric")
+                    self.pokemonType1Text.text = "전기"
+                    self.pokemonType1Background.backgroundColor = TypeColor.electric
+                case "ice":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Ice")
+                    self.pokemonType1Text.text = "얼음"
+                    self.pokemonType1Background.backgroundColor = TypeColor.ice
+                case "fighting":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Fighting")
+                    self.pokemonType1Text.text = "격투"
+                    self.pokemonType1Background.backgroundColor = TypeColor.fighting
+                case "poison":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Poison")
+                    self.pokemonType1Text.text = "독"
+                    self.pokemonType1Background.backgroundColor = TypeColor.poison
+                case "ground":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Ground")
+                    self.pokemonType1Text.text = "땅"
+                    self.pokemonType1Background.backgroundColor = TypeColor.ground
+                case "flying":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Flying")
+                    self.pokemonType1Text.text = "비행"
+                    self.pokemonType1Background.backgroundColor = TypeColor.flying
+                case "psychic":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Psychic")
+                    self.pokemonType1Text.text = "에스퍼"
+                    self.pokemonType1Background.backgroundColor = TypeColor.psychic
+                case "bug":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Bug")
+                    self.pokemonType1Text.text = "벌레"
+                    self.pokemonType1Background.backgroundColor = TypeColor.bug
+                case "rock":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Rock")
+                    self.pokemonType1Text.text = "바위"
+                    self.pokemonType1Background.backgroundColor = TypeColor.rock
+                case "ghost":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Ghost")
+                    self.pokemonType1Text.text = "고스트"
+                    self.pokemonType1Background.backgroundColor = TypeColor.ghost
+                case "dragon":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Dragon")
+                    self.pokemonType1Text.text = "드래곤"
+                    self.pokemonType1Background.backgroundColor = TypeColor.dragon
+                case "dark":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Dark")
+                    self.pokemonType1Text.text = "악"
+                    self.pokemonType1Background.backgroundColor = TypeColor.dark
+                case "steel":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Steel")
+                    self.pokemonType1Text.text = "강철"
+                    self.pokemonType1Background.backgroundColor = TypeColor.steel
+                case "fairy":
+                    self.pokemonType1Icon.image = #imageLiteral(resourceName: "Fairy")
+                    self.pokemonType1Text.text = "페어리"
+                    self.pokemonType1Background.backgroundColor = TypeColor.fairy
+                default:
+                    break
+                }
+
+                if !json.types.filter { $0.slot == 2 }.isEmpty {
+                    switch json.types.filter { $0.slot == 2 }[0].type.name {
+                    case "normal":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Normal")
+                        self.pokemonType2Text.text = "노말"
+                        self.pokemonType2Background.backgroundColor = TypeColor.normal
+                    case "fire":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Fire")
+                        self.pokemonType2Text.text = "불꽃"
+                        self.pokemonType2Background.backgroundColor = TypeColor.fire
+                    case "water":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Water")
+                        self.pokemonType2Text.text = "물"
+                        self.pokemonType2Background.backgroundColor = TypeColor.water
+                    case "grass":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Grass")
+                        self.pokemonType2Text.text = "풀"
+                        self.pokemonType2Background.backgroundColor = TypeColor.grass
+                    case "electric":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Electric")
+                        self.pokemonType2Text.text = "전기"
+                        self.pokemonType2Background.backgroundColor = TypeColor.electric
+                    case "ice":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Ice")
+                        self.pokemonType2Text.text = "얼음"
+                        self.pokemonType2Background.backgroundColor = TypeColor.ice
+                    case "fighting":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Fighting")
+                        self.pokemonType2Text.text = "격투"
+                        self.pokemonType2Background.backgroundColor = TypeColor.fighting
+                    case "poison":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Poison")
+                        self.pokemonType2Text.text = "독"
+                        self.pokemonType2Background.backgroundColor = TypeColor.poison
+                    case "ground":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Ground")
+                        self.pokemonType2Text.text = "땅"
+                        self.pokemonType2Background.backgroundColor = TypeColor.ground
+                    case "flying":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Flying")
+                        self.pokemonType2Text.text = "비행"
+                        self.pokemonType2Background.backgroundColor = TypeColor.flying
+                    case "psychic":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Psychic")
+                        self.pokemonType2Text.text = "에스퍼"
+                        self.pokemonType2Background.backgroundColor = TypeColor.psychic
+                    case "bug":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Bug")
+                        self.pokemonType2Text.text = "벌레"
+                        self.pokemonType2Background.backgroundColor = TypeColor.bug
+                    case "rock":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Rock")
+                        self.pokemonType2Text.text = "바위"
+                        self.pokemonType2Background.backgroundColor = TypeColor.rock
+                    case "ghost":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Ghost")
+                        self.pokemonType2Text.text = "고스트"
+                        self.pokemonType2Background.backgroundColor = TypeColor.ghost
+                    case "dragon":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Dragon")
+                        self.pokemonType2Text.text = "드래곤"
+                        self.pokemonType2Background.backgroundColor = TypeColor.dragon
+                    case "dark":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Dark")
+                        self.pokemonType2Text.text = "악"
+                        self.pokemonType2Background.backgroundColor = TypeColor.dark
+                    case "steel":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Steel")
+                        self.pokemonType2Text.text = "강철"
+                        self.pokemonType2Background.backgroundColor = TypeColor.steel
+                    case "fairy":
+                        self.pokemonType2Icon.image = #imageLiteral(resourceName: "Fairy")
+                        self.pokemonType2Text.text = "페어리"
+                        self.pokemonType2Background.backgroundColor = TypeColor.fairy
+                    default:
+                        break
+                    }
+                }
+
+                guard let imageURLString = json.sprites.other.officialArtwork.frontDefault else { return }
+                guard let imageURL = URL(string: imageURLString) else { return }
+                let imageRequest = URLRequest(url: imageURL)
+
+                URLSession(configuration: .default).dataTask(with: imageRequest) { imageData, imageResponse, imageError in
+                    if let imageError {
+                        print("Image Error: \(imageError.localizedDescription)")
+                        return
+                    }
+
+                    guard let imageData else {
+                        print("Image Error: Data Error")
+                        return
+                    }
+
+                    guard let image = UIImage(data: imageData) else {
+                        print("Image Data Error")
+                        return
+                    }
+
+                    DispatchQueue.main.async {
+                        self.pokemonSprite.image = image
+                    }
+                }.resume()
+            }
+        }.resume()
+
+        guard let pokemonSpeciesUrl = URL(string: "https://pokeapi.co/api/v2/pokemon-species/\(number)") else { return }
+        let pokemonSpeciesRequest = URLRequest(url: pokemonSpeciesUrl)
+
+        URLSession(configuration: .default).dataTask(with: pokemonSpeciesRequest) { data, response, error in
+            if let error {
+                print("Error: \(error.localizedDescription)")
+                return
+            }
+
+            guard let data else {
+                print("Error: Request fail")
+                return
+            }
+
+            guard let json = try? JSONDecoder().decode(PokemonSpeciesInfo.self, from: data) else {
+                print("Error: Data Decoding error")
+                return
+            }
+
+            DispatchQueue.main.async {
+                self.pokemonName.text = json.names.filter { $0.language.name == "ko" }.isEmpty ? json.names[0].name : json.names.filter { $0.language.name == "ko" }[0].name
+                self.pokemonGenus.text = json.genera.filter { $0.language.name == "ko" }.isEmpty ? json.genera[0].genus : json.genera.filter { $0.language.name == "ko" }[0].genus
+                self.pokemonDexDetail.text = json.flavorTextEntries.filter { $0.language.name == "ko" }.isEmpty ? json.flavorTextEntries[0].flavorText : json.flavorTextEntries.filter { $0.language.name == "ko" }[0].flavorText
+            }
+        }.resume()
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/PokemonDex/TodaysPokemonViewController.swift
+++ b/PokemonDex/TodaysPokemonViewController.swift
@@ -495,7 +495,7 @@ class TodaysPokemonViewController: UIViewController {
     }(UIStackView())
 
     private let pokemonNumber: UILabel = {
-        $0.text = "No.1"
+        $0.text = "No."
         $0.font = .systemFont(ofSize: 15)
         $0.textColor = .white
         $0.translatesAutoresizingMaskIntoConstraints = false
@@ -503,7 +503,7 @@ class TodaysPokemonViewController: UIViewController {
     }(UILabel())
 
     private let pokemonName: UILabel = {
-        $0.text = "이상해씨"
+        $0.text = ""
         $0.font = .systemFont(ofSize: 16)
         $0.textColor = .white
         $0.translatesAutoresizingMaskIntoConstraints = false
@@ -511,7 +511,7 @@ class TodaysPokemonViewController: UIViewController {
     }(UILabel())
 
     private let pokemonGenus: UILabel = {
-        $0.text = "씨앗 포켓몬"
+        $0.text = "포켓몬"
         $0.font = .systemFont(ofSize: 12)
         $0.textColor = .white
         $0.translatesAutoresizingMaskIntoConstraints = false
@@ -532,7 +532,6 @@ class TodaysPokemonViewController: UIViewController {
     }(UIView())
 
     private let pokemonType1Background: UIView = {
-        $0.backgroundColor = TypeColor.grass
         $0.layer.cornerRadius = 10
         $0.layer.masksToBounds = true
         $0.translatesAutoresizingMaskIntoConstraints = false
@@ -549,14 +548,12 @@ class TodaysPokemonViewController: UIViewController {
     }(UIStackView())
 
     private let pokemonType1Icon: UIImageView = {
-        $0.image = #imageLiteral(resourceName: "Grass")
         $0.contentMode = .scaleToFill
         $0.translatesAutoresizingMaskIntoConstraints = false
         return $0
     }(UIImageView())
 
     private let pokemonType1Text: UILabel = {
-        $0.text = "풀"
         $0.font = .systemFont(ofSize: 12)
         $0.textColor = .white
         $0.translatesAutoresizingMaskIntoConstraints = false
@@ -564,7 +561,6 @@ class TodaysPokemonViewController: UIViewController {
     }(UILabel())
 
     private let pokemonType2Background: UIView = {
-        $0.backgroundColor = TypeColor.poison
         $0.layer.cornerRadius = 10
         $0.layer.masksToBounds = true
         $0.translatesAutoresizingMaskIntoConstraints = false
@@ -581,14 +577,12 @@ class TodaysPokemonViewController: UIViewController {
     }(UIStackView())
 
     private let pokemonType2Icon: UIImageView = {
-        $0.image = #imageLiteral(resourceName: "Poison")
         $0.contentMode = .scaleToFill
         $0.translatesAutoresizingMaskIntoConstraints = false
         return $0
     }(UIImageView())
 
     private let pokemonType2Text: UILabel = {
-        $0.text = "독"
         $0.font = .systemFont(ofSize: 12)
         $0.textColor = .white
         $0.translatesAutoresizingMaskIntoConstraints = false
@@ -596,7 +590,7 @@ class TodaysPokemonViewController: UIViewController {
     }(UILabel())
 
     private let pokemonDexDetail: UILabel = {
-        $0.text = "태어났을 때부터 등에 식물의 씨앗이 있으며 조금씩 크게 자란다."
+        $0.text = "설명"
         $0.font = .systemFont(ofSize: 14)
         $0.textColor = .white
         $0.numberOfLines = 0


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 화면에 진입할 때 랜덤한 포켓몬의 정보를 보여주기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- PokeAPI의 응답을 받기 위한 Model 추가
- PokeAPI에 URLSession으로 데이터 요청하고, 응답을 UI에 반영하는 기능 추가

## ToDo 📆 (남은 작업)
- 없음

## ScreenShot 📷 (참고 사진)
<img src="https://github.com/user-attachments/assets/06e32318-66ca-4b20-965f-dce544a96b86" width=300>

## Reference 🔗
- [Apple Developer - Foundation - URLSession](https://developer.apple.com/documentation/foundation/urlsession)
- [Apple Developer - Foundation - JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder)
  - [Apple Developer - Swift - Codable](https://developer.apple.com/documentation/swift/codable)
- [Apple Developer - Dispatch - DispatchQueue](https://developer.apple.com/documentation/dispatch/dispatchqueue)
  - [Apple Developer - Dispatch - DispatchQueue - main](https://developer.apple.com/documentation/dispatch/dispatchqueue/1781006-main)
  - [Apple Developer - Dispatch - DispatchQueue - async(group:qos:flags:execute:)](https://developer.apple.com/documentation/dispatch/dispatchqueue/2016098-async)

## Close Issues 🔒 (닫을 Issue)
Close #3.
