### PR TITLE
[Fix] 포켓몬 목록을 확인한 후 오늘의 포켓몬으로 돌아오면 자동 갱신되는 문제

### DIFF
--- a/PokemonDex/PokemonDexViewController.swift
+++ b/PokemonDex/PokemonDexViewController.swift
@@ -14,6 +14,7 @@ class PokemonDexViewController: UIViewController {
         case pokemonDexGrid
     }
 
+    private var todaysPokemon = PokemonInfo(id: 0)
     private var pokemonDexGridDataSource: UICollectionViewDiffableDataSource<Section, Int>!
 
     private lazy var pokemonDexListCollectionView: UICollectionView = {

--- a/PokemonDex/PokemonDexViewController.swift
+++ b/PokemonDex/PokemonDexViewController.swift
@@ -40,8 +40,11 @@ class PokemonDexViewController: UIViewController {
             pokemonDexListCollectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
 
-        configureDataSource()
-        applyPokemonDexGridSnapshot()
+        Task {
+            todaysPokemon = try await requestPokemonDexAsyncData(pokemonDexNumber: Int.random(in: 1...1025))
+            configureDataSource()
+            applyPokemonDexGridSnapshot()
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/PokemonDex/PokemonDexViewController.swift
+++ b/PokemonDex/PokemonDexViewController.swift
@@ -86,7 +86,7 @@ class PokemonDexViewController: UIViewController {
         return PokemonInfo(id: pokemonDexNumber, pokemon: pokemonModel, species: pokemonSpeciesModel, sprite: pokemonImageData)
     }
 
-    private func requestPokemonDexData(pokemonNumberLabel: UILabel, pokemonNameLabel: UILabel, pokemonGenusLabel: UILabel, pokemonDexDetail: UITextView, pokemonSprite: UIImageView, type1Icon: UIImageView, type1Text: UILabel, type1Background: UIView, type2Icon: UIImageView, type2Text: UILabel, type2Background: UIView) {
+    private func configureTodaysPokemonData(pokemonNumberLabel: UILabel, pokemonNameLabel: UILabel, pokemonGenusLabel: UILabel, pokemonDexDetail: UITextView, pokemonSprite: UIImageView, type1Icon: UIImageView, type1Text: UILabel, type1Background: UIView, type2Icon: UIImageView, type2Text: UILabel, type2Background: UIView) {
         pokemonNumberLabel.text = "No.\(todaysPokemon.id)"
         guard let imageData = todaysPokemon.sprite, let image = UIImage(data: imageData) else { return }
         pokemonSprite.image = image
@@ -236,12 +236,12 @@ class PokemonDexViewController: UIViewController {
             buttonConfig.background.image = #imageLiteral(resourceName: "MonsterBall")
             cell.titleImageButton.configuration = buttonConfig
 
-            self.requestPokemonDexData(pokemonNumberLabel: cell.pokemonNumber, pokemonNameLabel: cell.pokemonName, pokemonGenusLabel: cell.pokemonGenus, pokemonDexDetail: cell.pokemonDexDetail, pokemonSprite: cell.pokemonSprite, type1Icon: cell.pokemonType1Icon, type1Text: cell.pokemonType1Text, type1Background: cell.pokemonType1Background, type2Icon: cell.pokemonType2Icon, type2Text: cell.pokemonType2Text, type2Background: cell.pokemonType2Background)
+            self.configureTodaysPokemonData(pokemonNumberLabel: cell.pokemonNumber, pokemonNameLabel: cell.pokemonName, pokemonGenusLabel: cell.pokemonGenus, pokemonDexDetail: cell.pokemonDexDetail, pokemonSprite: cell.pokemonSprite, type1Icon: cell.pokemonType1Icon, type1Text: cell.pokemonType1Text, type1Background: cell.pokemonType1Background, type2Icon: cell.pokemonType2Icon, type2Text: cell.pokemonType2Text, type2Background: cell.pokemonType2Background)
 
             let action = UIAction { _ in
                 Task {
                     self.todaysPokemon = try await self.requestPokemonDexAsyncData(pokemonDexNumber: Int.random(in: 1...1025))
-                    self.requestPokemonDexData(pokemonNumberLabel: cell.pokemonNumber, pokemonNameLabel: cell.pokemonName, pokemonGenusLabel: cell.pokemonGenus, pokemonDexDetail: cell.pokemonDexDetail, pokemonSprite: cell.pokemonSprite, type1Icon: cell.pokemonType1Icon, type1Text: cell.pokemonType1Text, type1Background: cell.pokemonType1Background, type2Icon: cell.pokemonType2Icon, type2Text: cell.pokemonType2Text, type2Background: cell.pokemonType2Background)
+                    self.configureTodaysPokemonData(pokemonNumberLabel: cell.pokemonNumber, pokemonNameLabel: cell.pokemonName, pokemonGenusLabel: cell.pokemonGenus, pokemonDexDetail: cell.pokemonDexDetail, pokemonSprite: cell.pokemonSprite, type1Icon: cell.pokemonType1Icon, type1Text: cell.pokemonType1Text, type1Background: cell.pokemonType1Background, type2Icon: cell.pokemonType2Icon, type2Text: cell.pokemonType2Text, type2Background: cell.pokemonType2Background)
                 }
 
                 UIView.animate(withDuration: 1) {

--- a/PokemonDex/PokemonDexViewController.swift
+++ b/PokemonDex/PokemonDexViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 
 class PokemonDexViewController: UIViewController {
 
+    // MARK: - Property
+
     enum Section: Int, CaseIterable {
         case todaysPokemon
         case pokemonDexGrid
@@ -17,6 +19,8 @@ class PokemonDexViewController: UIViewController {
     private var todaysPokemon = PokemonInfo(id: 0)
     private var pokemonDexGridDataSource: UICollectionViewDiffableDataSource<Section, Int>!
 
+    // MARK: - View
+
     private lazy var pokemonDexListCollectionView: UICollectionView = {
         $0.backgroundColor = .clear
         $0.translatesAutoresizingMaskIntoConstraints = false
@@ -24,6 +28,8 @@ class PokemonDexViewController: UIViewController {
     }(UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewCompositionalLayout(sectionProvider: { section, env in
         self.configureSection(for: section)
     })))
+
+    // MARK: - Life Cycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -56,6 +62,8 @@ class PokemonDexViewController: UIViewController {
         viewGradient.frame = view.bounds
         view.layer.insertSublayer(viewGradient, at: 0)
     }
+
+    // MARK: - Method
 
     private func requestPokemonDexAsyncData(pokemonDexNumber: Int) async throws -> PokemonInfo {
         guard let pokemonImageURL = URL(string: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/\(pokemonDexNumber).png") else { fatalError() }

--- a/PokemonDex/PokemonDexViewController.swift
+++ b/PokemonDex/PokemonDexViewController.swift
@@ -231,14 +231,17 @@ class PokemonDexViewController: UIViewController {
             self.requestPokemonDexData(pokemonNumberLabel: cell.pokemonNumber, pokemonNameLabel: cell.pokemonName, pokemonGenusLabel: cell.pokemonGenus, pokemonDexDetail: cell.pokemonDexDetail, pokemonSprite: cell.pokemonSprite, type1Icon: cell.pokemonType1Icon, type1Text: cell.pokemonType1Text, type1Background: cell.pokemonType1Background, type2Icon: cell.pokemonType2Icon, type2Text: cell.pokemonType2Text, type2Background: cell.pokemonType2Background)
 
             let action = UIAction { _ in
+                Task {
+                    self.todaysPokemon = try await self.requestPokemonDexAsyncData(pokemonDexNumber: Int.random(in: 1...1025))
+                    self.requestPokemonDexData(pokemonNumberLabel: cell.pokemonNumber, pokemonNameLabel: cell.pokemonName, pokemonGenusLabel: cell.pokemonGenus, pokemonDexDetail: cell.pokemonDexDetail, pokemonSprite: cell.pokemonSprite, type1Icon: cell.pokemonType1Icon, type1Text: cell.pokemonType1Text, type1Background: cell.pokemonType1Background, type2Icon: cell.pokemonType2Icon, type2Text: cell.pokemonType2Text, type2Background: cell.pokemonType2Background)
+                }
+
                 UIView.animate(withDuration: 1) {
                     cell.titleImageButton.transform = CGAffineTransform(rotationAngle: .pi)
-                    cell.pokemonSprite.image = #imageLiteral(resourceName: "MonsterBall")
                 }
 
                 UIView.animate(withDuration: 1) {
                     cell.titleImageButton.transform = CGAffineTransform(rotationAngle: .ulpOfOne)
-                    self.requestPokemonDexData(pokemonDexNumber: Int.random(in: 1...1025), pokemonNumberLabel: cell.pokemonNumber, pokemonNameLabel: cell.pokemonName, pokemonGenusLabel: cell.pokemonGenus, pokemonDexDetail: cell.pokemonDexDetail, pokemonSprite: cell.pokemonSprite, type1Icon: cell.pokemonType1Icon, type1Text: cell.pokemonType1Text, type1Background: cell.pokemonType1Background, type2Icon: cell.pokemonType2Icon, type2Text: cell.pokemonType2Text, type2Background: cell.pokemonType2Background)
                 }
             }
 

--- a/PokemonDex/PokemonDexViewController.swift
+++ b/PokemonDex/PokemonDexViewController.swift
@@ -47,7 +47,7 @@ class PokemonDexViewController: UIViewController {
         ])
 
         Task {
-            todaysPokemon = try await requestPokemonDexAsyncData(pokemonDexNumber: Int.random(in: 1...1025))
+            todaysPokemon = try await requestPokemonDexData(pokemonDexNumber: Int.random(in: 1...1025))
             configureDataSource()
             applyPokemonDexGridSnapshot()
         }
@@ -65,7 +65,7 @@ class PokemonDexViewController: UIViewController {
 
     // MARK: - Method
 
-    private func requestPokemonDexAsyncData(pokemonDexNumber: Int) async throws -> PokemonInfo {
+    private func requestPokemonDexData(pokemonDexNumber: Int) async throws -> PokemonInfo {
         guard let pokemonImageURL = URL(string: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/\(pokemonDexNumber).png") else { fatalError() }
         let pokemonImageRequest = URLRequest(url: pokemonImageURL)
 
@@ -240,7 +240,7 @@ class PokemonDexViewController: UIViewController {
 
             let action = UIAction { _ in
                 Task {
-                    self.todaysPokemon = try await self.requestPokemonDexAsyncData(pokemonDexNumber: Int.random(in: 1...1025))
+                    self.todaysPokemon = try await self.requestPokemonDexData(pokemonDexNumber: Int.random(in: 1...1025))
                     self.configureTodaysPokemonData(pokemonNumberLabel: cell.pokemonNumber, pokemonNameLabel: cell.pokemonName, pokemonGenusLabel: cell.pokemonGenus, pokemonDexDetail: cell.pokemonDexDetail, pokemonSprite: cell.pokemonSprite, type1Icon: cell.pokemonType1Icon, type1Text: cell.pokemonType1Text, type1Background: cell.pokemonType1Background, type2Icon: cell.pokemonType2Icon, type2Text: cell.pokemonType2Text, type2Background: cell.pokemonType2Background)
                 }
 

--- a/PokemonDex/PokemonDexViewController.swift
+++ b/PokemonDex/PokemonDexViewController.swift
@@ -54,6 +54,26 @@ class PokemonDexViewController: UIViewController {
         view.layer.insertSublayer(viewGradient, at: 0)
     }
 
+    private func requestPokemonDexAsyncData(pokemonDexNumber: Int) async throws -> PokemonInfo {
+        guard let pokemonImageURL = URL(string: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/\(pokemonDexNumber).png") else { fatalError() }
+        let pokemonImageRequest = URLRequest(url: pokemonImageURL)
+
+        let (pokemonImageData, _) = try await URLSession(configuration: .default).data(for: pokemonImageRequest)
+
+        guard let pokemonUrl = URL(string: "https://pokeapi.co/api/v2/pokemon/\(pokemonDexNumber)") else { fatalError() }
+        let pokemonRequest = URLRequest(url: pokemonUrl)
+
+        let (pokemonData, _) = try await URLSession(configuration: .default).data(for: pokemonRequest)
+        let pokemonModel = try JSONDecoder().decode(PokemonModel.self, from: pokemonData)
+
+        guard let pokemonSpeciesUrl = URL(string: "https://pokeapi.co/api/v2/pokemon-species/\(pokemonDexNumber)") else { fatalError() }
+        let pokemonSpeciesRequest = URLRequest(url: pokemonSpeciesUrl)
+
+        let (pokemonSpeciesData, _) = try await URLSession(configuration: .default).data(for: pokemonSpeciesRequest)
+        let pokemonSpeciesModel = try JSONDecoder().decode(PokemonSpeciesModel.self, from: pokemonSpeciesData)
+
+        return PokemonInfo(id: pokemonDexNumber, pokemon: pokemonModel, species: pokemonSpeciesModel, sprite: pokemonImageData)
+    }
 
     private func requestPokemonDexData(pokemonNumberLabel: UILabel, pokemonNameLabel: UILabel, pokemonGenusLabel: UILabel, pokemonDexDetail: UITextView, pokemonSprite: UIImageView, type1Icon: UIImageView, type1Text: UILabel, type1Background: UIView, type2Icon: UIImageView, type2Text: UILabel, type2Background: UIView) {
         pokemonNumberLabel.text = "No.\(todaysPokemon.id)"

--- a/PokemonDex/PokemonModel.swift
+++ b/PokemonDex/PokemonModel.swift
@@ -7,6 +7,13 @@
 
 import Foundation
 
+struct PokemonInfo {
+    var id: Int
+    var pokemon: PokemonModel?
+    var species: PokemonSpeciesModel?
+    var sprite: Data?
+}
+
 /**
  포켓몬의 정보를 가져오는 데 필요한 데이터
  


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 오늘의 포켓몬을 확인한 후, 포켓몬 목록을 확인하고 다시 오늘의 포켓몬으로 돌아오면 오늘의 포켓몬이 자동으로 새로고침되는 문제를 해결하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 포켓몬 정보를 모아둔 PokemonInfo Model 추가
- 오늘의 포켓몬 정보를 담는 todaysPokemon 변수 추가
- 일부 메서드 수정

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)
<img src="https://github.com/user-attachments/assets/898d7549-5d45-4983-984b-ddbf09db020f" width="300">

## Reference 🔗
- [Apple Developer - Swift - Task](https://developer.apple.com/documentation/swift/task)
- [Apple Developer - Foundation - URLSession - data(for:delegate:)](https://developer.apple.com/documentation/foundation/urlsession/3767352-data)
- [Swift.org - Concurrency](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/#app-top)

## Close Issues 🔒 (닫을 Issue)
Close #12.
