### PR TITLE
[Feature] 도감 설명 변경 기능 추가

### DIFF
--- a/PokemonDex.xcodeproj/project.pbxproj
+++ b/PokemonDex.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		2610A34A2C73384700BD3C5F /* PokemonDexHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2610A3492C73384700BD3C5F /* PokemonDexHeader.swift */; };
 		2610A3502C75E1BA00BD3C5F /* PokemonDexDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2610A34F2C75E1BA00BD3C5F /* PokemonDexDetailViewController.swift */; };
 		2610A3522C7667E400BD3C5F /* PokemonDexDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2610A3512C7667E400BD3C5F /* PokemonDexDetailView.swift */; };
+		2610A3592C77CFA300BD3C5F /* PokemonGameVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2610A3582C77CFA300BD3C5F /* PokemonGameVersion.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +39,7 @@
 		2610A3492C73384700BD3C5F /* PokemonDexHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonDexHeader.swift; sourceTree = "<group>"; };
 		2610A34F2C75E1BA00BD3C5F /* PokemonDexDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonDexDetailViewController.swift; sourceTree = "<group>"; };
 		2610A3512C7667E400BD3C5F /* PokemonDexDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonDexDetailView.swift; sourceTree = "<group>"; };
+		2610A3582C77CFA300BD3C5F /* PokemonGameVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonGameVersion.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,6 +78,7 @@
 				2610A3112C6546BF00BD3C5F /* AppDelegate.swift */,
 				2610A3132C6546BF00BD3C5F /* SceneDelegate.swift */,
 				2610A3272C659B1400BD3C5F /* PokemonType.swift */,
+				2610A3582C77CFA300BD3C5F /* PokemonGameVersion.swift */,
 				2610A31A2C6546C100BD3C5F /* Assets.xcassets */,
 				2610A31C2C6546C100BD3C5F /* LaunchScreen.storyboard */,
 				2610A31F2C6546C100BD3C5F /* Info.plist */,
@@ -182,6 +185,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2610A3592C77CFA300BD3C5F /* PokemonGameVersion.swift in Sources */,
 				2610A3262C65646000BD3C5F /* PokemonDexViewController.swift in Sources */,
 				2610A3502C75E1BA00BD3C5F /* PokemonDexDetailViewController.swift in Sources */,
 				2610A33C2C6D554600BD3C5F /* TodaysPokemonCell.swift in Sources */,

--- a/PokemonDex/PokemonGameVersion.swift
+++ b/PokemonDex/PokemonGameVersion.swift
@@ -143,4 +143,94 @@ enum PokemonGameVersion: String, CaseIterable {
         }
     }
 
+    func configureVersionColor() -> UIColor {
+        switch self {
+            case .red:
+                return #colorLiteral(red: 0.9872214198, green: 0.02776993625, blue: 0.1776115596, alpha: 1)
+            case .blue:
+                return #colorLiteral(red: 0.2375460267, green: 0.4122451842, blue: 0.7074590921, alpha: 1)
+            case .yellow:
+                return #colorLiteral(red: 0.9960586429, green: 0.878088057, blue: 0.06920240819, alpha: 1)
+            case .gold:
+                return #colorLiteral(red: 0.9549127221, green: 0.7405667901, blue: 0.0102605857, alpha: 1)
+            case .silver:
+                return #colorLiteral(red: 0.7845865488, green: 0.9056451917, blue: 0.9891819358, alpha: 1)
+            case .crystal:
+                return #colorLiteral(red: 0.4125355482, green: 0.3342987299, blue: 0.4383142591, alpha: 1)
+            case .ruby:
+                return #colorLiteral(red: 0.8363432884, green: 0.2572698593, blue: 0.2343947589, alpha: 1)
+            case .sapphire:
+                return #colorLiteral(red: 0.2724832594, green: 0.5316601396, blue: 0.8556486964, alpha: 1)
+            case .emerald:
+                return #colorLiteral(red: 0.2192952931, green: 0.6998054981, blue: 0.4582480788, alpha: 1)
+            case .fireRed:
+                return #colorLiteral(red: 0.9178231359, green: 0.2593289018, blue: 0.04524021596, alpha: 1)
+            case .leafGreen:
+                return #colorLiteral(red: 0.6621687412, green: 0.804192543, blue: 0.1656166911, alpha: 1)
+            case .diamond:
+                return #colorLiteral(red: 0.4584398866, green: 0.6443131566, blue: 0.7943369746, alpha: 1)
+            case .pearl:
+                return #colorLiteral(red: 0.8531146646, green: 0.6918874383, blue: 0.7210992575, alpha: 1)
+            case .platinum:
+                return #colorLiteral(red: 0.8061820865, green: 0.7225016356, blue: 0.378385365, alpha: 1)
+            case .heartGold:
+                return #colorLiteral(red: 1, green: 0.9715375304, blue: 0.694054544, alpha: 1)
+            case .soulSilver:
+                return #colorLiteral(red: 0.8504073024, green: 0.8753228784, blue: 0.8963804841, alpha: 1)
+            case .black:
+                return #colorLiteral(red: 0.09188076109, green: 0.08200898021, blue: 0.08649811894, alpha: 1)
+            case .white:
+                return #colorLiteral(red: 0.9999999404, green: 1, blue: 1, alpha: 1)
+            case .colosseum:
+                return #colorLiteral(red: 0.8626797199, green: 0.7691994309, blue: 0.5268123746, alpha: 1)
+            case .xd:
+                return #colorLiteral(red: 0.9805395007, green: 0.7804870009, blue: 0.4140536487, alpha: 1)
+            case .black2:
+                return #colorLiteral(red: 0.1459518969, green: 0.1165554747, blue: 0.1084592864, alpha: 1)
+            case .white2:
+                return #colorLiteral(red: 0.9058824182, green: 0.9058822989, blue: 0.9015743732, alpha: 1)
+            case .x:
+                return #colorLiteral(red: 0.02674455196, green: 0.3228054047, blue: 0.5792497993, alpha: 1)
+            case .y:
+                return #colorLiteral(red: 0.6760847569, green: 0.05990961939, blue: 0.1342695355, alpha: 1)
+            case .omegaRuby:
+                return #colorLiteral(red: 0.8877932429, green: 0.1337813735, blue: 0.2375866175, alpha: 1)
+            case .alphaSapphire:
+                return #colorLiteral(red: 0.09750121087, green: 0.3342819214, blue: 0.6117435098, alpha: 1)
+            case .sun:
+                return #colorLiteral(red: 0.9693110585, green: 0.8465139866, blue: 0.04175425321, alpha: 1)
+            case .moon:
+                return #colorLiteral(red: 0.4591799378, green: 0.7605519891, blue: 0.934501946, alpha: 1)
+            case .ultraSun:
+                return #colorLiteral(red: 0.9947518706, green: 0.8331705928, blue: 0.1582370102, alpha: 1)
+            case .ultraMoon:
+                return #colorLiteral(red: 0.5512629151, green: 0.7466254234, blue: 0.8882303834, alpha: 1)
+            case .lgp:
+                return #colorLiteral(red: 0.9621109366, green: 0.7813293338, blue: 0.05673216283, alpha: 1)
+            case .lge:
+                return #colorLiteral(red: 0.7780203223, green: 0.4508313537, blue: 0.160946995, alpha: 1)
+            case .sword:
+                return #colorLiteral(red: 0.01841805503, green: 0.3029564619, blue: 0.6253349781, alpha: 1)
+            case .shield:
+                return #colorLiteral(red: 0.4893606901, green: 0.01651152223, blue: 0.001352610416, alpha: 1)
+            case .theIsleOfArmor:
+                return #colorLiteral(red: 0.9505909085, green: 0.8472730517, blue: 0.1573674083, alpha: 1)
+            case .theCrownTundra:
+                return #colorLiteral(red: 0.01682768203, green: 0.4700337052, blue: 0.5298088789, alpha: 1)
+            case .brilliantDiamond:
+                return #colorLiteral(red: 0.1431352198, green: 0.6406204104, blue: 0.9049867988, alpha: 1)
+            case .shiningPearl:
+                return #colorLiteral(red: 0.8642807603, green: 0.7854510546, blue: 0.8897984624, alpha: 1)
+            case .legendsArceus:
+                return #colorLiteral(red: 0.5001068711, green: 0.7557575107, blue: 0.6046666503, alpha: 1)
+            case .scarlet:
+                return #colorLiteral(red: 0.8852034211, green: 0.01397596486, blue: 0.07024814934, alpha: 1)
+            case .violet:
+                return #colorLiteral(red: 0.6315546632, green: 0.2231458426, blue: 0.4929769039, alpha: 1)
+            case .theTealMask:
+                return #colorLiteral(red: 0.1103086099, green: 0.7323105931, blue: 0.6880854964, alpha: 1)
+            case .theIndigoDisk:
+                return #colorLiteral(red: 0.01168273855, green: 0.2910616398, blue: 0.6873884201, alpha: 1)
+        }
+    }
 }

--- a/PokemonDex/PokemonGameVersion.swift
+++ b/PokemonDex/PokemonGameVersion.swift
@@ -1,0 +1,55 @@
+//
+//  PokemonGameVersion.swift
+//  PokemonDex
+//
+//  Created by 김민택 on 8/23/24.
+//
+
+import UIKit
+
+enum PokemonGameVersion: String, CaseIterable {
+    case red = "red"
+    case blue = "blue"
+    case yellow = "yellow"
+    case gold = "gold"
+    case silver = "silver"
+    case crystal = "crystal"
+    case ruby = "ruby"
+    case sapphire = "sapphire"
+    case emerald = "emerald"
+    case fireRed = "firered"
+    case leafGreen = "leafgreen"
+    case diamond = "diamond"
+    case pearl = "pearl"
+    case platinum = "platinum"
+    case heartGold = "heartgold"
+    case soulSilver = "soulsilver"
+    case black = "black"
+    case white = "white"
+    case colosseum = "colosseum"
+    case xd = "XD"
+    case black2 = "black-2"
+    case white2 = "white-2"
+    case x = "x"
+    case y = "y"
+    case omegaRuby = "omega-ruby"
+    case alphaSapphire = "alpha-sapphire"
+    case sun = "sun"
+    case moon = "moon"
+    case ultraSun = "ultra-sun"
+    case ultraMoon = "ultra-moon"
+    case lgp = "lets-go-pikachu"
+    case lge = "lets-go-eevee"
+    case sword = "sword"
+    case shield = "shield"
+    case theIsleOfArmor = "the-isle-of-armor"
+    case theCrownTundra = "the-crown-tundra"
+    case brilliantDiamond = "brilliant-diamond"
+    case shiningPearl = "shining-pearl"
+    case legendsArceus = "legends-arceus"
+    case scarlet = "scarlet"
+    case violet = "violet"
+    case theTealMask = "the-teal-mask"
+    case theIndigoDisk = "the-indigo-disk"
+
+}

--- a/PokemonDex/PokemonGameVersion.swift
+++ b/PokemonDex/PokemonGameVersion.swift
@@ -52,4 +52,95 @@ enum PokemonGameVersion: String, CaseIterable {
     case theTealMask = "the-teal-mask"
     case theIndigoDisk = "the-indigo-disk"
 
+    func configureVersionName() -> String {
+        switch self {
+            case .red:
+                return "레드"
+            case .blue:
+                return "블루"
+            case .yellow:
+                return "피카츄"
+            case .gold:
+                return "골드"
+            case .silver:
+                return "실버"
+            case .crystal:
+                return "크리스탈"
+            case .ruby:
+                return "루비"
+            case .sapphire:
+                return "사파이어"
+            case .emerald:
+                return "에메랄드"
+            case .fireRed:
+                return "파이어레드"
+            case .leafGreen:
+                return "리프그린"
+            case .diamond:
+                return "디아루가"
+            case .pearl:
+                return "펄기아"
+            case .platinum:
+                return "기라티나"
+            case .heartGold:
+                return "하트골드"
+            case .soulSilver:
+                return "소울실버"
+            case .black:
+                return "블랙"
+            case .white:
+                return "화이트"
+            case .colosseum:
+                return "콜로세움"
+            case .xd:
+                return "XD"
+            case .black2:
+                return "블랙 2"
+            case .white2:
+                return "화이트 2"
+            case .x:
+                return "X"
+            case .y:
+                return "Y"
+            case .omegaRuby:
+                return "오메가루비"
+            case .alphaSapphire:
+                return "알파사파이어"
+            case .sun:
+                return "썬"
+            case .moon:
+                return "문"
+            case .ultraSun:
+                return "울트라썬"
+            case .ultraMoon:
+                return "울트라문"
+            case .lgp:
+                return "레츠고! 피카츄"
+            case .lge:
+                return "레츠고! 이브이"
+            case .sword:
+                return "소드"
+            case .shield:
+                return "실드"
+            case .theIsleOfArmor:
+                return "갑옷의 외딴섬"
+            case .theCrownTundra:
+                return "왕관의 설원"
+            case .brilliantDiamond:
+                return "브릴리언트 다이아몬드"
+            case .shiningPearl:
+                return "샤이닝 펄"
+            case .legendsArceus:
+                return "LEGENDS 아르세우스"
+            case .scarlet:
+                return "스칼렛"
+            case .violet:
+                return "바이올렛"
+            case .theTealMask:
+                return "벽록의 가면"
+            case .theIndigoDisk:
+                return "남청의 원반"
+        }
+    }
+
 }

--- a/PokemonDex/ViewControllers/PokemonDexDetailViewController.swift
+++ b/PokemonDex/ViewControllers/PokemonDexDetailViewController.swift
@@ -34,7 +34,7 @@ class PokemonDexDetailViewController: UIViewController {
             guard let species = selectedPokemon.species else { return }
             let name = species.names.filter { $0.language.name == "ko" }.isEmpty ? species.name : species.names.filter { $0.language.name == "ko" }[0].name
             navigationItem.title = name
-            pokemonDexDetailView.configurePokemonSpeciesData(number: selectedPokemon.id, name: name, genera: species.genera.filter { $0.language.name == "ko" }.isEmpty ? species.genera[0].genus : species.genera.filter { $0.language.name == "ko" }[0].genus, dexDetail: species.flavorTextEntries.filter { $0.language.name == "ko" }.isEmpty ? species.flavorTextEntries[0].flavorText : species.flavorTextEntries.filter { $0.language.name == "ko" }[0].flavorText)
+            pokemonDexDetailView.configurePokemonSpeciesData(number: selectedPokemon.id, name: name, genera: species.genera.filter { $0.language.name == "ko" }.isEmpty ? species.genera[0].genus : species.genera.filter { $0.language.name == "ko" }[0].genus)
 
             guard let sprite = selectedPokemon.sprite else { return }
             pokemonDexDetailView.configurePokemonSprite(imageData: sprite)

--- a/PokemonDex/ViewControllers/PokemonDexDetailViewController.swift
+++ b/PokemonDex/ViewControllers/PokemonDexDetailViewController.swift
@@ -49,6 +49,16 @@ class PokemonDexDetailViewController: UIViewController {
 
             guard let pokemon = selectedPokemon.pokemon else { return }
             pokemonDexDetailView.configurePokemonData(type1: pokemon.types[0].type.name, type2: pokemon.types.count == 2 ? pokemon.types[1].type.name : nil)
+
+            pokemonDexDetailView.pokemonDexTypeSelectionButton.menu = UIMenu(title: "도감 종류", children: species.flavorTextEntries.filter { $0.language.name == "ko" }.map { flavorTextType in
+                UIAction(title: PokemonGameVersion(rawValue: flavorTextType.version.name)!.configureVersionName(), handler: { _ in
+                    let color = PokemonGameVersion(rawValue: flavorTextType.version.name)?.configureVersionColor()
+                    self.pokemonDexDetailView.pokemonDexTypeSelectionButton.configuration?.baseForegroundColor = color
+                    self.pokemonDexDetailView.pokemonDexTypeSelectionButton.layer.borderColor = color?.cgColor
+                    self.pokemonDexDetailView.pokemonDexTypeSelectionButton.configuration?.title = PokemonGameVersion(rawValue: flavorTextType.version.name)?.configureVersionName()
+                    self.pokemonDexDetailView.configurePokemonDexDetail(dexDetail: flavorTextType.flavorText)
+                })
+            })
         }
     }
 

--- a/PokemonDex/ViewControllers/PokemonDexDetailViewController.swift
+++ b/PokemonDex/ViewControllers/PokemonDexDetailViewController.swift
@@ -36,6 +36,14 @@ class PokemonDexDetailViewController: UIViewController {
             navigationItem.title = name
             pokemonDexDetailView.configurePokemonSpeciesData(number: selectedPokemon.id, name: name, genera: species.genera.filter { $0.language.name == "ko" }.isEmpty ? species.genera[0].genus : species.genera.filter { $0.language.name == "ko" }[0].genus)
 
+            let baseFlavorText = species.flavorTextEntries.filter { $0.language.name == "ko" }
+            pokemonDexDetailView.configurePokemonDexDetail(dexDetail: baseFlavorText.isEmpty ? "해당 언어로된 도감 설명이 없습니다." : baseFlavorText[0].flavorText)
+            pokemonDexDetailView.pokemonDexTypeSelectionButton.configuration?.title = baseFlavorText.isEmpty ? "오류" : PokemonGameVersion(rawValue: baseFlavorText[0].version.name)?.configureVersionName()
+            let gameVersionColor = baseFlavorText.isEmpty ? .black : PokemonGameVersion(rawValue: baseFlavorText[0].version.name)?.configureVersionColor()
+            pokemonDexDetailView.pokemonDexTypeSelectionButton.configuration?.baseForegroundColor = gameVersionColor
+            pokemonDexDetailView.pokemonDexTypeSelectionButton.layer.borderColor = gameVersionColor?.cgColor
+            pokemonDexDetailView.pokemonDexTypeSelectionButton.showsMenuAsPrimaryAction = true
+
             guard let sprite = selectedPokemon.sprite else { return }
             pokemonDexDetailView.configurePokemonSprite(imageData: sprite)
 

--- a/PokemonDex/Views/PokemonDexDetailView.swift
+++ b/PokemonDex/Views/PokemonDexDetailView.swift
@@ -288,13 +288,13 @@ class PokemonDexDetailView: UIView {
             pokemonDexTypeSelectionButton.rightAnchor.constraint(equalTo: pokemonDexFooter.rightAnchor, constant: -16)
         ])
 
-        pokemonDexTypeSelectionButton.layer.borderColor = UIColor.red.cgColor
+        pokemonDexTypeSelectionButton.layer.borderColor = UIColor.black.cgColor
         pokemonDexTypeSelectionButton.layer.borderWidth = 2
         pokemonDexTypeSelectionButton.layer.cornerRadius = 16
 
         var dexTypeButtonConfig = UIButton.Configuration.bordered()
-        dexTypeButtonConfig.title = "스칼렛"
-        dexTypeButtonConfig.baseForegroundColor = .red
+        dexTypeButtonConfig.title = "버전"
+        dexTypeButtonConfig.baseForegroundColor = .black
         dexTypeButtonConfig.baseBackgroundColor = .white
         pokemonDexTypeSelectionButton.configuration = dexTypeButtonConfig
         pokemonDexTypeSelectionButton.titleLabel?.font = .boldSystemFont(ofSize: 14)

--- a/PokemonDex/Views/PokemonDexDetailView.swift
+++ b/PokemonDex/Views/PokemonDexDetailView.swift
@@ -325,11 +325,14 @@ class PokemonDexDetailView: UIView {
         }
     }
 
-    func configurePokemonSpeciesData(number: Int, name: String, genera: String, dexDetail: String) {
+    func configurePokemonSpeciesData(number: Int, name: String, genera: String) {
         titleText.text = "#\(number) \(name)"
         pokemonNumber.text = "No. \(number)"
         pokemonName.text = name
         pokemonGenus.text = genera
+    }
+
+    func configurePokemonDexDetail(dexDetail: String) {
         pokemonDexDetail.text = dexDetail
         pokemonDexDetail.setContentOffset(.zero, animated: false)
     }

--- a/PokemonDex/Views/PokemonDexDetailView.swift
+++ b/PokemonDex/Views/PokemonDexDetailView.swift
@@ -182,7 +182,7 @@ class PokemonDexDetailView: UIView {
         return $0
     }(UIView())
 
-    private let pokemonDexTypeSelectionButton: UIButton = {
+    let pokemonDexTypeSelectionButton: UIButton = {
         $0.translatesAutoresizingMaskIntoConstraints = false
         return $0
     }(UIButton())


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 다양한 게임 버전의 도감 설명을 보기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 게임 버전을 구분하기 위한 PokemonGameVersion Enum 추가
- 포켓몬 게임 버전의 한글명 및 대표 색상을 반환하기 위한 메서드 추가 (`configureVersionName`, `configureVersionColor`)
- 포켓몬 도감 설명을 설정하기 위한 메서드 분리 (`configurePokemonDexDetail`)
- 도감 버전 설명 변경 기능 추가

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)
<img src="https://github.com/user-attachments/assets/772e0360-c9ee-406d-9c16-8ec7a7443dcd" width=300>

## Reference 🔗
- [Apple Developer - UIKit - UIButton](https://developer.apple.com/documentation/uikit/uibutton)
  - [Apple Developer - UIKit- UIButton - changesSelectionAsPrimaryAction](https://developer.apple.com/documentation/uikit/uibutton/3752184-changesselectionasprimaryaction)
  - [Apple Developer - UIKit - UIButton - menu](https://developer.apple.com/documentation/uikit/uibutton/3601189-menu)
- [Apple Developer - UIKit - UIMenu](https://developer.apple.com/documentation/uikit/uimenu)
- [Apple Developer - UIKit - UIAction](https://developer.apple.com/documentation/uikit/uiaction)

## Close Issues 🔒 (닫을 Issue)
Close #18.
